### PR TITLE
ci: add lint, packaging and release workflows (incl. cargo publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 0.5.2)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (verify only: no commit, tag, release or publish)'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Required by crates-io-auth-action for OIDC trusted publishing.
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$VERSION' is not a semver version (e.g. 0.5.2)"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version_tag=v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Fail if the tag already exists
+        run: |
+          TAG="${{ steps.version.outputs.version_tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists"
+            exit 1
+          fi
+
+      - name: Update Cargo.toml version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "0,/^version = \".*\"/s//version = \"${VERSION}\"/" Cargo.toml
+          cargo update -p cooklang-reports
+          grep -m1 '^version' Cargo.toml
+
+      - name: Verify
+        run: |
+          cargo fmt --check
+          cargo clippy --all-targets -- -D warnings
+          cargo test
+          cargo publish --dry-run
+
+      - name: Commit version bump
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): ${{ steps.version.outputs.version }}"
+          git push origin HEAD:main
+
+      - name: Create and push tag
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          TAG="${{ steps.version.outputs.version_tag }}"
+          git tag "${TAG}"
+          git push origin "${TAG}"
+
+      - name: Create GitHub release
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.version_tag }}
+          name: Release ${{ steps.version.outputs.version_tag }}
+          generate_release_notes: true
+
+      # Trusted publishing: no CARGO_REGISTRY_TOKEN secret needed, but the crate
+      # must have this repo + workflow registered as a Trusted Publisher on
+      # crates.io. Same setup as cooklang-rs and CookCLI.
+      - name: Authenticate to crates.io
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish to crates.io
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,42 @@ env:
 
 jobs:
   build:
-
+    name: Test
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      # Catches packaging problems (missing files, bad metadata) on a PR,
+      # rather than when a release tries to publish to crates.io.
+      - name: Check the crate packages cleanly
+        run: cargo publish --dry-run

--- a/src/filters/numeric.rs
+++ b/src/filters/numeric.rs
@@ -12,12 +12,13 @@ pub fn numeric_filter(value: &str) -> Result<f64, Error> {
         // Handle fractions (e.g., "1/4")
         let parts: Vec<&str> = numeric_part.split('/').collect();
         if parts.len() == 2
-            && let (Ok(num), Ok(denom)) = (parts[0].parse::<f64>(), parts[1].parse::<f64>()) {
-                let fraction = num / denom;
-                if fraction.is_finite() {
-                    return Ok(fraction);
-                }
+            && let (Ok(num), Ok(denom)) = (parts[0].parse::<f64>(), parts[1].parse::<f64>())
+        {
+            let fraction = num / denom;
+            if fraction.is_finite() {
+                return Ok(fraction);
             }
+        }
     } else if let Ok(num) = numeric_part.parse::<f64>() {
         return Ok(num);
     }

--- a/src/functions/aisle.rs
+++ b/src/functions/aisle.rs
@@ -75,10 +75,11 @@ pub fn aisled(state: &State, ingredients: Value) -> Value {
                     if let Ok(iter) = ingredients.try_iter() {
                         for item in iter {
                             if let Ok(name) = item.get_attr("name")
-                                && name.as_str() == Some(&ingredient_name) {
-                                    category_items.push(item);
-                                    break;
-                                }
+                                && name.as_str() == Some(&ingredient_name)
+                            {
+                                category_items.push(item);
+                                break;
+                            }
                         }
                     }
                 }
@@ -96,10 +97,11 @@ pub fn aisled(state: &State, ingredients: Value) -> Value {
                     if let Ok(iter) = ingredients.try_iter() {
                         for item in iter {
                             if let Ok(name) = item.get_attr("name")
-                                && name.as_str() == Some(&ingredient_name) {
-                                    other_items.push(item);
-                                    break;
-                                }
+                                && name.as_str() == Some(&ingredient_name)
+                            {
+                                other_items.push(item);
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/functions/ingredient_list.rs
+++ b/src/functions/ingredient_list.rs
@@ -78,14 +78,13 @@ fn process_ingredients(
 ) -> Result<()> {
     let iter = ingredients
         .try_iter()
-        .map_err(|e| anyhow!("ingredients must be an array: {}", e))?;
+        .map_err(|e| anyhow!("ingredients must be an array: {e}"))?;
 
     for item in iter {
         // Check if this is a recipe reference
         let is_reference = item
             .get_attr("reference")
-            .map(|v| v.is_true())
-            .unwrap_or(false);
+            .is_ok_and(|v| v.is_true());
 
         if is_reference && expand_references {
             // Handle recipe reference only if expansion is enabled
@@ -114,7 +113,7 @@ fn process_regular_ingredient(
 ) -> Result<()> {
     let name = item
         .get_attr("name")
-        .map_err(|e| anyhow!("Failed to get ingredient name: {}", e))?
+        .map_err(|e| anyhow!("Failed to get ingredient name: {e}"))?
         .as_str()
         .ok_or_else(|| anyhow!("Ingredient name must be a string"))?
         .to_string();
@@ -162,7 +161,7 @@ fn process_recipe_reference(
 ) -> Result<()> {
     let name = item
         .get_attr("name")
-        .map_err(|e| anyhow!("Failed to get ingredient name: {}", e))?
+        .map_err(|e| anyhow!("Failed to get ingredient name: {e}"))?
         .as_str()
         .ok_or_else(|| anyhow!("Ingredient name must be a string"))?
         .to_string();
@@ -212,7 +211,7 @@ fn process_recipe_reference(
 
     let mut recipe = parse_result
         .output()
-        .ok_or_else(|| anyhow!("Failed to get recipe output for '{}'", reference_path))?
+        .ok_or_else(|| anyhow!("Failed to get recipe output for '{reference_path}'"))?
         .clone();
 
     // Apply scaling based on quantity if present

--- a/src/functions/ingredient_list.rs
+++ b/src/functions/ingredient_list.rs
@@ -82,9 +82,7 @@ fn process_ingredients(
 
     for item in iter {
         // Check if this is a recipe reference
-        let is_reference = item
-            .get_attr("reference")
-            .is_ok_and(|v| v.is_true());
+        let is_reference = item.get_attr("reference").is_ok_and(|v| v.is_true());
 
         if is_reference && expand_references {
             // Handle recipe reference only if expansion is enabled
@@ -129,21 +127,22 @@ fn process_regular_ingredient(
 
     // Parse and add quantity if present
     if let Ok(qty_val) = item.get_attr("quantity")
-        && let Ok(qty) = quantity_from_value(&qty_val) {
-            // Apply parent scaling if needed
-            let final_qty = if (parent_scaling - 1.0).abs() > f64::EPSILON {
-                match qty.value() {
-                    QuantityValue::Number(n) => Quantity::new(
-                        QuantityValue::Number((n.value() * parent_scaling).into()),
-                        qty.unit().map(String::from),
-                    ),
-                    _ => qty,
-                }
-            } else {
-                qty
-            };
-            grouped.add(&final_qty, get_converter());
-        }
+        && let Ok(qty) = quantity_from_value(&qty_val)
+    {
+        // Apply parent scaling if needed
+        let final_qty = if (parent_scaling - 1.0).abs() > f64::EPSILON {
+            match qty.value() {
+                QuantityValue::Number(n) => Quantity::new(
+                    QuantityValue::Number((n.value() * parent_scaling).into()),
+                    qty.unit().map(String::from),
+                ),
+                _ => qty,
+            }
+        } else {
+            qty
+        };
+        grouped.add(&final_qty, get_converter());
+    }
 
     // Add the ingredient to the list using the parser's methods
     list.add_ingredient(display_name, &grouped, get_converter());
@@ -216,26 +215,27 @@ fn process_recipe_reference(
 
     // Apply scaling based on quantity if present
     if let Ok(qty_val) = item.get_attr("quantity")
-        && let Ok(qty) = quantity_from_value(&qty_val) {
-            if let Some(unit) = qty.unit() {
-                // Extract numeric value from quantity
-                let target_value = match qty.value() {
-                    QuantityValue::Number(n) => n.value(),
-                    _ => 1.0,
-                };
+        && let Ok(qty) = quantity_from_value(&qty_val)
+    {
+        if let Some(unit) = qty.unit() {
+            // Extract numeric value from quantity
+            let target_value = match qty.value() {
+                QuantityValue::Number(n) => n.value(),
+                _ => 1.0,
+            };
 
-                recipe
+            recipe
                     .scale_to_target(target_value, Some(unit), get_converter())
                     .with_context(|| {
                         format!(
                             "Failed to scale recipe '{reference_path}' with target {target_value} {unit}"
                         )
                     })?;
-            } else if let QuantityValue::Number(n) = qty.value() {
-                // Just a number, use as scaling factor
-                recipe.scale(n.value(), get_converter());
-            }
+        } else if let QuantityValue::Number(n) = qty.value() {
+            // Just a number, use as scaling factor
+            recipe.scale(n.value(), get_converter());
         }
+    }
 
     // Apply parent scaling if needed
     if (parent_scaling - 1.0).abs() > f64::EPSILON {

--- a/src/functions/pantry.rs
+++ b/src/functions/pantry.rs
@@ -37,14 +37,15 @@ pub fn excluding_pantry(state: &State, ingredients: Value) -> Value {
                 for item in iter {
                     // Get ingredient name
                     if let Ok(name) = item.get_attr("name")
-                        && let Some(name_str) = name.as_str() {
-                            // Check if this ingredient is NOT in the pantry
-                            let in_pantry = pantry_conf.has_ingredient(name_str);
+                        && let Some(name_str) = name.as_str()
+                    {
+                        // Check if this ingredient is NOT in the pantry
+                        let in_pantry = pantry_conf.has_ingredient(name_str);
 
-                            if !in_pantry {
-                                filtered.push(item);
-                            }
+                        if !in_pantry {
+                            filtered.push(item);
                         }
+                    }
                 }
             }
 
@@ -98,14 +99,15 @@ pub fn from_pantry(state: &State, ingredients: Value) -> Value {
                 for item in iter {
                     // Get ingredient name
                     if let Ok(name) = item.get_attr("name")
-                        && let Some(name_str) = name.as_str() {
-                            // Check if this ingredient IS in the pantry
-                            let in_pantry = pantry_conf.has_ingredient(name_str);
+                        && let Some(name_str) = name.as_str()
+                    {
+                        // Check if this ingredient IS in the pantry
+                        let in_pantry = pantry_conf.has_ingredient(name_str);
 
-                            if in_pantry {
-                                filtered.push(item);
-                            }
+                        if in_pantry {
+                            filtered.push(item);
                         }
+                    }
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,10 @@ pub fn render_template_with_config(
 }
 
 /// Build an environment for the given template, registering built-in and extension functions.
-fn template_environment<'a>(template: &'a str, config: &'a Config) -> Result<Environment<'a>, Error> {
+fn template_environment<'a>(
+    template: &'a str,
+    config: &'a Config,
+) -> Result<Environment<'a>, Error> {
     let mut env = Environment::new();
 
     // Enable debug mode for better error messages

--- a/src/model/quantity.rs
+++ b/src/model/quantity.rs
@@ -66,15 +66,16 @@ pub fn quantity_from_value(qty_val: &minijinja::Value) -> Result<CooklangQuantit
             && let (Ok(start), Ok(end)) = (
                 parts[0].trim().parse::<f64>(),
                 parts[1].trim().parse::<f64>(),
-            ) {
-                return Ok(CooklangQuantity::new(
-                    QuantityValue::Range {
-                        start: start.into(),
-                        end: end.into(),
-                    },
-                    unit,
-                ));
-            }
+            )
+        {
+            return Ok(CooklangQuantity::new(
+                QuantityValue::Range {
+                    start: start.into(),
+                    end: end.into(),
+                },
+                unit,
+            ));
+        }
         // If range parsing fails, treat as text
         Ok(CooklangQuantity::new(QuantityValue::Text(value_str), unit))
     } else {

--- a/tests/extension_test.rs
+++ b/tests/extension_test.rs
@@ -1,4 +1,4 @@
-use cooklang_reports::{render_template_with_config, Config, ConfigExtension};
+use cooklang_reports::{Config, ConfigExtension, render_template_with_config};
 use minijinja::Environment;
 use std::sync::{Arc, Mutex};
 
@@ -20,9 +20,9 @@ impl ConfigExtension for CountingExtension {
 #[test]
 fn extension_function_is_registered() {
     let counter = Arc::new(Mutex::new(0u32));
-    let config = Config::builder()
-        .build()
-        .with_extension(CountingExtension { counter: counter.clone() });
+    let config = Config::builder().build().with_extension(CountingExtension {
+        counter: counter.clone(),
+    });
 
     let recipe = "@flour{1}";
     let template = "{{ bump() }}-{{ bump() }}";

--- a/tests/extension_test.rs
+++ b/tests/extension_test.rs
@@ -1,3 +1,8 @@
+// Integration test: the crate's `missing_docs` and `unwrap_used` lints are meant
+// for the library surface, not for test scaffolding.
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
 use cooklang_reports::{Config, ConfigExtension, render_template_with_config};
 use minijinja::Environment;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
CI here only ran `build` and `test` — no fmt, no clippy, no packaging check — and there was **no release workflow at all**. Releases were fully manual and nothing published to crates.io. That is what stalled the dependency chain in cooklang/cookcli#366: 0.5.1 had to be published by hand.

## Commits, deliberately split

Adding lint gates to a repo that has never had them means fixing what drifted. Those fixes are separate from the CI change so each stays reviewable:

1. **`fix(lint): satisfy clippy`** — mechanical `cargo clippy --fix`: 4 × inline format args, and `map(..).unwrap_or(false)` → `is_ok_and`. No behaviour change.
2. **`style: cargo fmt`** — formatting only.
3. **`fix(lint): allow missing_docs and unwrap_used in the integration test`** — the crate sets these lints in `[lints]`, which is right for the library surface but not for test scaffolding; under `--all-targets -D warnings` they failed the build. Allowed in the test file rather than weakening the lint for the library.
4. **`ci: add lint, packaging and release workflows`** — the actual change.

## `rust.yml` — every push/PR

Now also runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and **`cargo publish --dry-run`**. That last one is the safety net: packaging breakage surfaces on a PR instead of mid-release.

## `release.yml` — new, `workflow_dispatch` with a version input

Bumps `Cargo.toml`, verifies (fmt/clippy/test/dry-run), commits, tags, cuts a GitHub release, and **publishes to crates.io**. Refuses to reuse an existing tag, and has a `dry_run` mode that verifies without releasing.

## Auth — one-time setup needed

Uses **OIDC trusted publishing** via `rust-lang/crates-io-auth-action@v1`, matching `cooklang-rs` and CookCLI, so there is no `CARGO_REGISTRY_TOKEN` secret to manage. It does need a Trusted Publisher registered for this crate first:

> crates.io → `cooklang-reports` → Settings → Trusted Publishing → add
> repository `cooklang/cooklang-reports`, workflow `release.yml`

Until then the publish step fails on auth; everything before it works, and `dry_run: true` is safe to run now. Happy to swap to a token secret if you prefer.

## Verification (CI toolchain, 1.97)
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — 0 issues
- `cargo test` — 3 suites pass
- `cargo publish --dry-run` — packages cleanly (`Uploading cooklang-reports v0.5.1`)

Refs cooklang/cookcli#366
