### PR TITLE
ci: exercise crates.io auth on dry runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,10 @@ jobs:
       # Trusted publishing: no CARGO_REGISTRY_TOKEN secret needed, but the crate
       # must have this repo + workflow registered as a Trusted Publisher on
       # crates.io. Same setup as cooklang-rs and CookCLI.
+      # Deliberately runs on dry runs too: this is the OIDC handshake with
+      # crates.io, so a dry run actually proves the Trusted Publisher config is
+      # correct. It only mints a token - nothing is uploaded.
       - name: Authenticate to crates.io
-        if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
 


### PR DESCRIPTION
Fixes a gap in the release workflow I added: the crates.io auth step was gated behind `dry_run != 'true'`, so a dry run **skipped the OIDC handshake entirely**.

That made the dry run far less useful than it looks. It verified fmt/clippy/tests/packaging, but never talked to crates.io — so it could not tell you whether the Trusted Publisher config was correct, which is precisely the thing you want to confirm *before* a real release depends on it. You would only find out at the final step of a live release, after the version bump had been committed, tagged and released.

Now the auth step runs on dry runs too. It only mints a short-lived token; the `cargo publish` step stays gated on `dry_run`, so nothing is uploaded.

Net effect: `dry_run: true` is now a genuine end-to-end rehearsal — verify → auth → stop.
